### PR TITLE
Add support for some content scanner endpoints.

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1648,7 +1648,7 @@ export class MatrixClient extends EventEmitter {
             return this.contentScannerInstance.downloadContent(mxcUrl, allowRemote);
         }
         const { domain, mediaId } = MXCUrl.parse(mxcUrl);
-        const path = `/_matrix/media/v3/download/${domain}/${mediaId}`;
+        const path = `/_matrix/media/v3/download/${encodeURIComponent(domain)}/${encodeURIComponent(mediaId)}`;
         const res = await this.doRequest("GET", path, { allow_remote: allowRemote }, null, null, true, null, true);
         return {
             data: res.body,

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -21,7 +21,7 @@ import { PowerLevelBounds } from "./models/PowerLevelBounds";
 import { EventKind } from "./models/events/EventKind";
 import { IdentityClient } from "./identity/IdentityClient";
 import { OpenIDConnectToken } from "./models/OpenIDConnect";
-import { doHttpRequest } from "./http";
+import { doHttpRequest, DoHttpRequestOpts } from "./http";
 import { Space, SpaceCreateOptions } from "./models/Spaces";
 import { PowerLevelAction } from "./models/PowerLevelAction";
 import { CryptoClient } from "./e2ee/CryptoClient";
@@ -46,6 +46,8 @@ import { RoomCreateOptions } from "./models/CreateRoom";
 import { PresenceState } from './models/events/PresenceEvent';
 import { IKeyBackupInfo, IKeyBackupInfoRetrieved, IKeyBackupInfoUnsigned, IKeyBackupInfoUpdate, IKeyBackupVersion, KeyBackupVersion } from "./models/KeyBackup";
 import { MatrixError } from "./models/MatrixError";
+import { MXCUrl } from "./models/MXCUrl";
+import { MatrixContentScannerClient } from "./MatrixContentScannerClient";
 
 const SYNC_BACKOFF_MIN_MS = 5000;
 const SYNC_BACKOFF_MAX_MS = 15000;
@@ -80,6 +82,13 @@ export class MatrixClient extends EventEmitter {
     public readonly crypto: CryptoClient;
 
     /**
+     * The Content Scanner API instance for this client. This is set if `opts.enableContentScanner`
+     * is true. The `downloadContent` and `crypto.decryptMedia` methods automatically go via
+     * the content scanner when this is set.
+     */
+    public readonly contentScannerInstance?: MatrixContentScannerClient;
+
+    /**
      * The DM manager instance for this client.
      */
     public readonly dms: DMs;
@@ -94,7 +103,7 @@ export class MatrixClient extends EventEmitter {
     private filterId = 0;
     private stopSyncing = false;
     private metricsInstance: Metrics = new Metrics();
-    private unstableApisInstance = new UnstableApis(this);
+    private readonly unstableApisInstance = new UnstableApis(this);
     private cachedVersions: ServerVersions;
     private versionsLastFetched = 0;
 
@@ -118,6 +127,7 @@ export class MatrixClient extends EventEmitter {
         public readonly accessToken: string,
         private storage: IStorageProvider = null,
         public readonly cryptoStore: ICryptoStorageProvider = null,
+        opts: { enableContentScanner?: boolean } = {},
     ) {
         super();
 
@@ -149,6 +159,10 @@ export class MatrixClient extends EventEmitter {
         if (!this.storage) this.storage = new MemoryStorageProvider();
 
         this.dms = new DMs(this);
+
+        if (opts.enableContentScanner) {
+            this.contentScannerInstance = new MatrixContentScannerClient(this);
+        }
     }
 
     /**
@@ -1587,11 +1601,8 @@ export class MatrixClient extends EventEmitter {
      * @returns {string} The HTTP URL for the content.
      */
     public mxcToHttp(mxc: string): string {
-        if (!mxc.startsWith("mxc://")) throw new Error("Not a MXC URI");
-        const parts = mxc.substring("mxc://".length).split('/');
-        const originHomeserver = parts[0];
-        const mediaId = parts.slice(1, parts.length).join('/');
-        return `${this.homeserverUrl}/_matrix/media/v3/download/${encodeURIComponent(originHomeserver)}/${encodeURIComponent(mediaId)}`;
+        const { domain, mediaId } = MXCUrl.parse(mxc);
+        return `${this.homeserverUrl}/_matrix/media/v3/download/${encodeURIComponent(domain)}/${encodeURIComponent(mediaId)}`;
     }
 
     /**
@@ -1633,12 +1644,10 @@ export class MatrixClient extends EventEmitter {
      * @returns {Promise<{data: Buffer, contentType: string}>} Resolves to the downloaded content.
      */
     public async downloadContent(mxcUrl: string, allowRemote = true): Promise<{ data: Buffer, contentType: string }> {
-        if (!mxcUrl.toLowerCase().startsWith("mxc://")) {
-            throw Error("'mxcUrl' does not begin with mxc://");
+        if (this.contentScannerInstance) {
+            return this.contentScannerInstance.downloadContent(mxcUrl, allowRemote);
         }
-        const urlParts = mxcUrl.substr("mxc://".length).split("/");
-        const domain = encodeURIComponent(urlParts[0]);
-        const mediaId = encodeURIComponent(urlParts[1].split("/")[0]);
+        const { domain, mediaId } = MXCUrl.parse(mxcUrl);
         const path = `/_matrix/media/v3/download/${domain}/${mediaId}`;
         const res = await this.doRequest("GET", path, { allow_remote: allowRemote }, null, null, true, null, true);
         return {
@@ -2095,7 +2104,8 @@ export class MatrixClient extends EventEmitter {
      * @returns {Promise<any>} Resolves to the response (body), rejected if a non-2xx status code was returned.
      */
     @timedMatrixClientFunctionCall()
-    public doRequest(method, endpoint, qs = null, body = null, timeout = 60000, raw = false, contentType = "application/json", noEncoding = false): Promise<any> {
+    public doRequest(method, endpoint, qs = null, body = null, timeout = 60000, raw = false,
+        contentType = "application/json", noEncoding = false, opts?: DoHttpRequestOpts): Promise<any> {
         if (this.impersonatedUserId) {
             if (!qs) qs = { "user_id": this.impersonatedUserId };
             else qs["user_id"] = this.impersonatedUserId;
@@ -2108,7 +2118,10 @@ export class MatrixClient extends EventEmitter {
         if (this.accessToken) {
             headers["Authorization"] = `Bearer ${this.accessToken}`;
         }
-        return doHttpRequest(this.homeserverUrl, method, endpoint, qs, body, headers, timeout, raw, contentType, noEncoding);
+        return doHttpRequest(
+            this.homeserverUrl, method, endpoint, qs, body, headers,
+            timeout, raw, contentType, noEncoding, opts,
+        );
     }
 }
 

--- a/src/MatrixContentScannerClient.ts
+++ b/src/MatrixContentScannerClient.ts
@@ -1,0 +1,66 @@
+import { EncryptedFile, MatrixClient } from ".";
+import { MXCUrl } from "./models/MXCUrl";
+
+export interface ContentScannerResult {
+    info: string;
+    clean: boolean;
+}
+export interface ContentScannerErrorResult {
+    info: string;
+    reason: string;
+}
+
+export class MatrixContentScannerError extends Error {
+    constructor(public readonly body: ContentScannerErrorResult) {
+        super(`Encountered error scanning content (${body.reason}): ${body.info}`);
+    }
+}
+
+const errorHandler = (_response, errBody) => {
+    return typeof (errBody) === "object" && 'reason' in errBody ?
+        new MatrixContentScannerError(errBody as ContentScannerErrorResult) : undefined;
+};
+
+/**
+ * API client for https://github.com/element-hq/matrix-content-scanner-python.
+ */
+export class MatrixContentScannerClient {
+    constructor(public readonly client: MatrixClient) {
+
+    }
+
+    public async scanContent(mxcUrl: string): Promise<ContentScannerResult> {
+        const { domain, mediaId } = MXCUrl.parse(mxcUrl);
+        const path = `/_matrix/media_proxy/unstable/scan/${domain}/${mediaId}`;
+        const res = await this.client.doRequest("GET", path, null, null, null, false, null, false, { errorHandler });
+        return res;
+    }
+
+    public async scanContentEncrypted(file: EncryptedFile): Promise<ContentScannerResult> {
+        // Sanity check.
+        MXCUrl.parse(file.url);
+        const path = `/_matrix/media_proxy/unstable/scan_encrypted`;
+        const res = await this.client.doRequest("POST", path, null, { file }, null, false, null, false, { errorHandler });
+        return res;
+    }
+
+    public async downloadContent(mxcUrl: string, allowRemote = true): ReturnType<MatrixClient["downloadContent"]> {
+        const { domain, mediaId } = MXCUrl.parse(mxcUrl);
+        const path = `/_matrix/media_proxy/unstable/download/${encodeURIComponent(domain)}/${encodeURIComponent(mediaId)}`;
+        const res = await this.client.doRequest("GET", path, null, null, null, true, null, true, { errorHandler });
+        return {
+            data: res.body,
+            contentType: res.headers["content-type"],
+        };
+    }
+
+    public async downloadEncryptedContent(file: EncryptedFile): Promise<Buffer> {
+        // Sanity check.
+        MXCUrl.parse(file.url);
+        const path = `/_matrix/media_proxy/unstable/download_encrypted`;
+        const res = await this.client.doRequest("POST", path, undefined, {
+            file,
+        }, null, true, null, true, { errorHandler });
+        return res.data;
+    }
+}

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -290,7 +290,7 @@ export class CryptoClient {
      */
     @requiresReady()
     public async decryptMedia(file: EncryptedFile): Promise<Buffer> {
-        const contents = (await this.client.downloadContent(file.url)).data;
+        const contents = await this.client.contentScannerInstance.downloadEncryptedContent(file);
         const encrypted = new EncryptedAttachment(
             contents,
             JSON.stringify(file),

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -290,7 +290,9 @@ export class CryptoClient {
      */
     @requiresReady()
     public async decryptMedia(file: EncryptedFile): Promise<Buffer> {
-        const contents = await this.client.contentScannerInstance.downloadEncryptedContent(file);
+        const contents = this.client.contentScannerInstance ?
+            await this.client.contentScannerInstance.downloadEncryptedContent(file) :
+            (await this.client.downloadContent(file.url)).data;
         const encrypted = new EncryptedAttachment(
             contents,
             JSON.stringify(file),

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export * from "./models/PowerLevelAction";
 export * from "./models/ServerVersions";
 export * from "./models/MatrixError";
 export * from "./models/CreateRoom";
+export * from "./models/MXCUrl";
 
 // Unstable models
 export * from "./models/unstable/MediaInfo";
@@ -112,6 +113,7 @@ export * from "./request";
 export * from "./PantalaimonClient";
 export * from "./SynchronousMatrixClient";
 export * from "./SynapseAdminApis";
+export * from "./MatrixContentScannerClient";
 export * from "./simple-validation";
 export * from "./b64";
 export * from "./http";

--- a/src/models/MXCUrl.ts
+++ b/src/models/MXCUrl.ts
@@ -1,0 +1,21 @@
+export class MXCUrl {
+    static parse(mxcUrl: string): MXCUrl {
+        if (!mxcUrl?.toLowerCase()?.startsWith("mxc://")) {
+            throw Error("mxcUrl does not begin with mxc://");
+        }
+        const [domain, mediaId] = mxcUrl.slice("mxc://".length).split("/", 2);
+        if (!domain) {
+            throw Error("missing domain component");
+        }
+        if (!mediaId) {
+            throw Error("missing mediaId component");
+        }
+        return new MXCUrl(domain, mediaId);
+    }
+
+    constructor(public domain: string, public mediaId: string) { }
+
+    public toString() {
+        return `mxc://${this.domain}/${this.mediaId}`;
+    }
+}

--- a/src/models/MXCUrl.ts
+++ b/src/models/MXCUrl.ts
@@ -1,16 +1,16 @@
 export class MXCUrl {
     static parse(mxcUrl: string): MXCUrl {
         if (!mxcUrl?.toLowerCase()?.startsWith("mxc://")) {
-            throw Error("mxcUrl does not begin with mxc://");
+            throw Error("Not a MXC URI");
         }
-        const [domain, mediaId] = mxcUrl.slice("mxc://".length).split("/", 2);
+        const [domain, ...mediaId] = mxcUrl.slice("mxc://".length).split("/");
         if (!domain) {
             throw Error("missing domain component");
         }
-        if (!mediaId) {
+        if (!mediaId?.length) {
             throw Error("missing mediaId component");
         }
-        return new MXCUrl(domain, mediaId);
+        return new MXCUrl(domain, mediaId.join('/'));
     }
 
     constructor(public domain: string, public mediaId: string) { }

--- a/src/models/MXCUrl.ts
+++ b/src/models/MXCUrl.ts
@@ -3,14 +3,15 @@ export class MXCUrl {
         if (!mxcUrl?.toLowerCase()?.startsWith("mxc://")) {
             throw Error("Not a MXC URI");
         }
-        const [domain, ...mediaId] = mxcUrl.slice("mxc://".length).split("/");
+        const [domain, ...mediaIdParts] = mxcUrl.slice("mxc://".length).split("/");
         if (!domain) {
             throw Error("missing domain component");
         }
-        if (!mediaId?.length) {
+        const mediaId = mediaIdParts?.join('/') ?? undefined;
+        if (!mediaId) {
             throw Error("missing mediaId component");
         }
-        return new MXCUrl(domain, mediaId.join('/'));
+        return new MXCUrl(domain, mediaId);
     }
 
     constructor(public domain: string, public mediaId: string) { }


### PR DESCRIPTION
This implements a handful of endpoints for https://github.com/element-hq/matrix-content-scanner-python & automatically invokes the content scanner when the client attempts to download media. 

## Checklist

* [ ] Tests written for all new code
* [ ] Linter has been satisfied
* [ ] Sign-off given on the changes (see CONTRIBUTING.md)
