### PR TITLE
Allow passing impersonated device ID to Intent

### DIFF
--- a/src/appservice/Appservice.ts
+++ b/src/appservice/Appservice.ts
@@ -209,6 +209,11 @@ export interface IAppserviceOptions {
          * Note that the appservice bot account is considered an intent.
          */
         encryption?: boolean;
+
+        /**
+         * Device ID for the bot user.
+         */
+        botDeviceId?: string;
     };
 }
 
@@ -363,11 +368,18 @@ export class Appservice extends EventEmitter {
     }
 
     /**
+     * Get the application service's "bot" user device ID.
+     */
+    public get botDeviceId(): string {
+        return this.options.intentOptions?.botDeviceId;
+    }
+
+    /**
      * Get the application service's "bot" Intent (the sender_localpart).
      * @returns {Intent} The intent for the application service itself.
      */
     public get botIntent(): Intent {
-        return this.getIntentForUserId(this.botUserId);
+        return this.getIntentForUserId(this.botUserId, this.botDeviceId);
     }
 
     /**
@@ -457,12 +469,13 @@ export class Appservice extends EventEmitter {
     /**
      * Gets an Intent for a given user ID.
      * @param {string} userId The user ID to get an Intent for.
+     * @param {string=} deviceId The user device ID to get an Intent for.
      * @returns {Intent} An Intent for the user.
      */
-    public getIntentForUserId(userId: string): Intent {
+    public getIntentForUserId(userId: string, deviceId?: string): Intent {
         let intent: Intent = this.intentsCache.get(userId);
         if (!intent) {
-            intent = new Intent(this.options, userId, this);
+            intent = new Intent(this.options, userId, this, deviceId);
             this.intentsCache.set(userId, intent);
             this.emit("intent.new", intent);
             if (this.options.intentOptions.encryption) {

--- a/src/appservice/Intent.ts
+++ b/src/appservice/Intent.ts
@@ -41,8 +41,9 @@ export class Intent {
      * @param {IAppserviceOptions} options The options for the application service.
      * @param {string} impersonateUserId The user ID to impersonate.
      * @param {Appservice} appservice The application service itself.
+     * @param {string=} impersonateDeviceId Optional device ID to impersonate with.
      */
-    constructor(private options: IAppserviceOptions, private impersonateUserId: string, private appservice: Appservice) {
+    constructor(private options: IAppserviceOptions, private impersonateUserId: string, private appservice: Appservice, private impersonateDeviceId?: string) {
         this.metrics = new Metrics(appservice.metrics);
         this.storage = options.storage;
         this.cryptoStorage = options.cryptoStorage;
@@ -65,7 +66,7 @@ export class Intent {
         this.client.metrics = new Metrics(this.appservice.metrics); // Metrics only go up by one parent
         this.unstableApisInstance = new UnstableAppserviceApis(this.client);
         if (this.impersonateUserId !== this.appservice.botUserId) {
-            this.client.impersonateUserId(this.impersonateUserId);
+            this.client.impersonateUserId(this.impersonateUserId, this.impersonateDeviceId);
         }
         if (this.options.joinStrategy) {
             this.client.setJoinStrategy(this.options.joinStrategy);

--- a/src/appservice/Intent.ts
+++ b/src/appservice/Intent.ts
@@ -81,6 +81,13 @@ export class Intent {
     }
 
     /**
+     * Gets the device ID this intent is for, if any.
+     */
+    public get deviceId(): string|undefined {
+        return this.impersonateDeviceId;
+    }
+
+    /**
      * Gets the underlying MatrixClient that powers this Intent.
      */
     public get underlyingClient(): MatrixClient {

--- a/test/appservice/AppserviceTest.ts
+++ b/test/appservice/AppserviceTest.ts
@@ -247,6 +247,34 @@ describe('Appservice', () => {
         const intent = appservice.botIntent;
         expect(intent).toBeDefined();
         expect(intent.userId).toEqual(appservice.botUserId);
+        expect(intent.deviceId).toBeUndefined();
+    });
+
+    it('should return an intent for the bot user with specific device', async () => {
+        const appservice = new Appservice({
+            port: 0,
+            bindAddress: '',
+            homeserverName: 'example.org',
+            homeserverUrl: 'https://localhost',
+            registration: {
+                as_token: "",
+                hs_token: "",
+                sender_localpart: "_bot_",
+                namespaces: {
+                    users: [{ exclusive: true, regex: "@_prefix_.*:.+" }],
+                    rooms: [],
+                    aliases: [],
+                },
+            },
+            intentOptions: {
+                botDeviceId: 'DEVICE',
+            },
+        });
+
+        const intent = appservice.botIntent;
+        expect(intent).toBeDefined();
+        expect(intent.userId).toEqual(appservice.botUserId);
+        expect(intent.deviceId).toEqual(appservice.botDeviceId);
     });
 
     it('should return a client for the bot user', async () => {
@@ -318,6 +346,7 @@ describe('Appservice', () => {
         const intent = appservice.getIntent("_prefix_testing");
         expect(intent).toBeDefined();
         expect(intent.userId).toEqual("@_prefix_testing:example.org");
+        expect(intent.deviceId).toBeUndefined();
     });
 
     it('should return an intent for any namespaced suffix', async () => {
@@ -341,6 +370,7 @@ describe('Appservice', () => {
         const intent = appservice.getIntentForSuffix("testing");
         expect(intent).toBeDefined();
         expect(intent.userId).toEqual("@_prefix_testing:example.org");
+        expect(intent.deviceId).toBeUndefined();
     });
 
     it('should return an intent for any user ID', async () => {
@@ -368,21 +398,25 @@ describe('Appservice', () => {
         intent = appservice.getIntentForUserId(userId);
         expect(intent).toBeDefined();
         expect(intent.userId).toEqual(userId);
+        expect(intent.deviceId).toBeUndefined();
 
         userId = "@_prefix_testing:example.org";
         intent = appservice.getIntentForUserId(userId);
         expect(intent).toBeDefined();
         expect(intent.userId).toEqual(userId);
+        expect(intent.deviceId).toBeUndefined();
 
         userId = "@_bot_:example.org";
         intent = appservice.getIntentForUserId(userId);
         expect(intent).toBeDefined();
         expect(intent.userId).toEqual(userId);
+        expect(intent.deviceId).toBeUndefined();
 
         userId = "@test_prefix_:example.org";
         intent = appservice.getIntentForUserId(userId);
         expect(intent).toBeDefined();
         expect(intent.userId).toEqual(userId);
+        expect(intent.deviceId).toBeUndefined();
     });
 
     it('should emit an event for a created intent', async () => {
@@ -422,6 +456,7 @@ describe('Appservice', () => {
             expect(intentSpy.callCount).toBe(index+1);
             expect(intent).toBeDefined();
             expect(intent.userId).toEqual(userId);
+            expect(intent.deviceId).toBeUndefined();
             expect(intent).toBe(newIntent);
         });
     });

--- a/test/appservice/IntentTest.ts
+++ b/test/appservice/IntentTest.ts
@@ -34,6 +34,7 @@ describe('Intent', () => {
         expect(intent.userId).toEqual(userId);
         expect(intent.underlyingClient).toBeDefined();
         expect((<any>intent.underlyingClient).impersonatedUserId).toBeUndefined();
+        expect((<any>intent.underlyingClient).impersonatedDeviceId).toBeUndefined();
         expect((<any>intent.underlyingClient).accessToken).toEqual(asToken);
         expect((<any>intent.underlyingClient).homeserverUrl).toEqual(hsUrl);
     });
@@ -56,6 +57,7 @@ describe('Intent', () => {
         expect(intent.userId).toEqual(userId);
         expect(intent.underlyingClient).toBeDefined();
         expect((<any>intent.underlyingClient).impersonatedUserId).toBeUndefined();
+        expect((<any>intent.underlyingClient).impersonatedDeviceId).toBeUndefined();
         expect((<any>intent.underlyingClient).accessToken).toEqual(asToken);
         expect((<any>intent.underlyingClient).homeserverUrl).toEqual(hsUrl);
         expect((<any>intent.underlyingClient).joinStrategy).toEqual(joinStrategy);
@@ -78,6 +80,30 @@ describe('Intent', () => {
         expect(intent.userId).toEqual(userId);
         expect(intent.underlyingClient).toBeDefined();
         expect((<any>intent.underlyingClient).impersonatedUserId).toEqual(userId);
+        expect((<any>intent.underlyingClient).impersonatedDeviceId).toBeUndefined();
+        expect((<any>intent.underlyingClient).accessToken).toEqual(asToken);
+        expect((<any>intent.underlyingClient).homeserverUrl).toEqual(hsUrl);
+    });
+
+    it('should prepare the underlying client for an impersonated user with specific device', async () => {
+        const userId = "@someone:example.org";
+        const botUserId = "@bot:example.org";
+        const botDeviceId = "DEVICE";
+        const asToken = "s3cret";
+        const hsUrl = "https://localhost";
+        const appservice = <Appservice>{ botUserId: botUserId };
+        const options = <IAppserviceOptions>{
+            homeserverUrl: hsUrl,
+            registration: {
+                as_token: asToken,
+            },
+        };
+
+        const intent = new Intent(options, userId, appservice, botDeviceId);
+        expect(intent.userId).toEqual(userId);
+        expect(intent.underlyingClient).toBeDefined();
+        expect((<any>intent.underlyingClient).impersonatedUserId).toEqual(userId);
+        expect((<any>intent.underlyingClient).impersonatedDeviceId).toEqual(botDeviceId);
         expect((<any>intent.underlyingClient).accessToken).toEqual(asToken);
         expect((<any>intent.underlyingClient).homeserverUrl).toEqual(hsUrl);
     });
@@ -101,6 +127,7 @@ describe('Intent', () => {
         expect(intent.userId).toEqual(userId);
         expect(intent.underlyingClient).toBeDefined();
         expect((<any>intent.underlyingClient).impersonatedUserId).toEqual(userId);
+        expect((<any>intent.underlyingClient).impersonatedDeviceId).toBeUndefined();
         expect((<any>intent.underlyingClient).accessToken).toEqual(asToken);
         expect((<any>intent.underlyingClient).homeserverUrl).toEqual(hsUrl);
         expect((<any>intent.underlyingClient).joinStrategy).toEqual(joinStrategy);


### PR DESCRIPTION
When creating an impersonating client for an appservice, allow passing in a device ID to use. This will make the requests have `org.matrix.msc3202.device_id` in the query string for the client requests.

Signed-off-by: Jason Robinson <jasonr@element.io>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)
