### PR TITLE
Fix `room.leave` event on `MatrixClient` emitter to emit when the bot is banned.

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -827,17 +827,16 @@ export class MatrixClient extends EventEmitter {
             for (const event of room['timeline']['events']) {
                 if (event['type'] !== 'm.room.member') continue;
                 if (event['state_key'] !== await this.getUserId()) continue;
-
-                const membership = event["content"]?.["membership"];
-                if (membership !== "leave" && membership !== "ban") continue;
-
-                const oldAge = leaveEvent && leaveEvent['unsigned'] && leaveEvent['unsigned']['age'] ? leaveEvent['unsigned']['age'] : 0;
-                const newAge = event['unsigned'] && event['unsigned']['age'] ? event['unsigned']['age'] : 0;
-                if (leaveEvent && oldAge < newAge) continue;
-
-                leaveEvent = event;
+                switch (event["content"]?.["membership"]) {
+                    case "leave":
+                    case "ban": {
+                        const oldAge = leaveEvent && leaveEvent['unsigned'] && leaveEvent['unsigned']['age'] ? leaveEvent['unsigned']['age'] : 0;
+                        const newAge = event['unsigned'] && event['unsigned']['age'] ? event['unsigned']['age'] : 0;
+                        if (leaveEvent && oldAge < newAge) continue;
+                        leaveEvent = event;
+                    }
+                }
             }
-
             if (!leaveEvent) {
                 LogService.warn("MatrixClientLite", "Left room " + roomId + " without receiving an event");
                 continue;

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -838,7 +838,7 @@ export class MatrixClient extends EventEmitter {
                 }
             }
             if (!leaveEvent) {
-                LogService.warn("MatrixClientLite", "Left room " + roomId + " without receiving an event");
+                LogService.error("MatrixClientLite", "Left room " + roomId + " without receiving an event");
                 continue;
             }
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->



## Checklist

* [x] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)

Signed-off-by: Gnuxie <Gnuxie@protonmail.com>