### PR TITLE
Fix logging for device ID being too early

### DIFF
--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -85,7 +85,6 @@ export class CryptoClient {
             throw new Error("Encryption not possible: server not revealing device ID");
         }
 
-
         const storagePath = await this.storage.getMachineStoragePath(deviceId);
 
         if (storedDeviceId !== deviceId) {

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -85,7 +85,6 @@ export class CryptoClient {
             throw new Error("Encryption not possible: server not revealing device ID");
         }
 
-        LogService.info("CryptoClient", "Starting with device ID:", this.deviceId); // info so all bots know for debugging
 
         const storagePath = await this.storage.getMachineStoragePath(deviceId);
 
@@ -94,7 +93,7 @@ export class CryptoClient {
         }
         this.deviceId = deviceId;
 
-        LogService.debug("CryptoClient", `Starting ${userId} with device ID:`, this.deviceId);
+        LogService.info("CryptoClient", `Starting ${userId} with device ID:`, this.deviceId); // info so all bots know for debugging
 
         const machine = await OlmMachine.initialize(
             new UserId(userId),
@@ -109,7 +108,7 @@ export class CryptoClient {
         this.deviceCurve25519 = identity.curve25519.toBase64();
         this.deviceEd25519 = identity.ed25519.toBase64();
 
-        LogService.debug("CryptoClient", "Running with device Ed25519 identity:", this.deviceEd25519); // info so all bots know for debugging
+        LogService.info("CryptoClient", `Running ${userId} with device Ed25519 identity:`, this.deviceEd25519); // info so all bots know for debugging
 
         this.ready = true;
     }


### PR DESCRIPTION
- Drop a redundant log line
- Log the userID for the case of appservice users where there might be several
- Log both with debug
- Log after setting `this.deviceId`

## Checklist

* [ ] Tests written for all new code
* [ ] Linter has been satisfied
* [ ] Sign-off given on the changes (see CONTRIBUTING.md)
