### PR TITLE
Fix: Send the Megolm rotation period to the rust-sdk in microseconds

### DIFF
--- a/src/e2ee/RustEngine.ts
+++ b/src/e2ee/RustEngine.ts
@@ -159,7 +159,8 @@ export class RustEngine {
             ? RustEncryptionAlgorithm.MegolmV1AesSha2
             : undefined;
         settings.historyVisibility = historyVis;
-        settings.rotationPeriod = BigInt(encEv.rotationPeriodMs);
+        // `rotationPeriod` is expressed in microseconds, whereas the room state is in milliseconds.
+        settings.rotationPeriod = BigInt(encEv.rotationPeriodMs) * 1000n;
         settings.rotationPeriodMessages = BigInt(encEv.rotationPeriodMessages);
 
         await this.lock.acquire(SYNC_LOCK_NAME, async () => {

--- a/test/encryption/RustEngineTest.ts
+++ b/test/encryption/RustEngineTest.ts
@@ -1,0 +1,64 @@
+import { EncryptionSettings } from "@matrix-org/matrix-sdk-crypto-nodejs";
+
+import { ICryptoRoomInformation, MembershipEvent, RoomEncryptionAlgorithm } from "../../src";
+import { RustEngine } from "../../src/e2ee/RustEngine";
+
+describe('RustEngine', () => {
+    describe('prepareEncrypt', () => {
+        const roomId = "!a:example.org";
+        const userId = "@alice:example.org";
+
+        /**
+         * Run {@link RustEngine#prepareEncrypt} against a stubbed machine, and return the
+         * {@link EncryptionSettings} it handed to `shareRoomKey`.
+         */
+        async function getSharedSettings(roomInfo: ICryptoRoomInformation): Promise<EncryptionSettings> {
+            let settings: EncryptionSettings;
+
+            const machine = {
+                updateTrackedUsers: () => Promise.resolve(),
+                outgoingRequests: () => Promise.resolve([]),
+                getMissingSessions: () => Promise.resolve(null),
+                shareRoomKey: (_roomId, _users, s: EncryptionSettings) => {
+                    settings = s;
+                    return Promise.resolve([]);
+                },
+            };
+
+            const client = {
+                getRoomMembersByMembership: () => Promise.resolve([new MembershipEvent({
+                    type: "m.room.member",
+                    sender: userId,
+                    state_key: userId,
+                    content: { membership: "join" },
+                })]),
+            };
+
+            await new RustEngine(<any>machine, <any>client).prepareEncrypt(roomId, roomInfo);
+
+            return settings;
+        }
+
+        // The rust-sdk expects `rotationPeriod` in microseconds, whereas `m.room.encryption`
+        // states it in milliseconds.
+        it('should convert the default rotation period to microseconds', async () => {
+            const settings = await getSharedSettings({
+                algorithm: RoomEncryptionAlgorithm.MegolmV1AesSha2,
+            });
+
+            expect(settings.rotationPeriod).toEqual(604800000000n); // 1 week
+            expect(settings.rotationPeriodMessages).toEqual(100n);
+        });
+
+        it('should convert a supplied rotation period to microseconds', async () => {
+            const settings = await getSharedSettings({
+                algorithm: RoomEncryptionAlgorithm.MegolmV1AesSha2,
+                rotation_period_ms: 86400000,
+                rotation_period_msgs: 50,
+            });
+
+            expect(settings.rotationPeriod).toEqual(86400000000n); // 1 day
+            expect(settings.rotationPeriodMessages).toEqual(50n);
+        });
+    });
+});


### PR DESCRIPTION
`EncryptionSettings.rotationPeriod` in `@matrix-org/matrix-sdk-crypto-nodejs` is in microseconds, but
`EncryptionEvent.rotationPeriodMs` returns `m.room.encryption`'s `rotation_period_ms`, which is
milliseconds. `RustEngine.prepareEncrypt` assigns one to the other unscaled, so every rotation period
reaches the rust-sdk 1000x shorter than intended.

The default is the clearest case: one week (604800000 ms) arrives as 604800000 µs, or 604.8 seconds.
matrix-sdk-crypto clamps the rotation period to a minimum of one hour before checking whether a session
has expired, so the one week default effectively becomes one hour. Rooms that set `rotation_period_ms`
explicitly are shortened the same way.

The fix multiplies by 1000 at the assignment, which is the only place the two units meet.
`rotationPeriodMs` mirrors room state and is public API, so it stays in milliseconds.
`rotationPeriodMessages` is a plain message count on both sides and is left alone.

The bindings' own default is a useful check here: `new EncryptionSettings().rotationPeriod` is
`604800000000n`, one week in microseconds.

### Tests

`test/encryption/RustEngineTest.ts` runs `prepareEncrypt` against a stubbed `OlmMachine` and asserts on
the `EncryptionSettings` passed to `shareRoomKey`:

- the default arrives as `604800000000n` µs, with `rotationPeriodMessages` at `100n`
- an explicit `rotation_period_ms: 86400000` arrives as `86400000000n` µs, with
  `rotation_period_msgs: 50` at `50n`

Both fail on current `main`, with `604800000n` and `86400000n`. The message-count assertions are there
so that scaling both fields is caught too.

This only corrects the rotation period passed to the rust-sdk. It doesn't alter the key-sharing flow,
and existing sessions keep the period they were created with.

## Checklist

* [x] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)